### PR TITLE
Optionally skip configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ The following environment variables are available to configure LDAP authenticati
 
 See the [docs](https://xbackbone.app/configuration.html#ldap-authentication) for explanation.
 
+# Manual configuration
+
+Sometimes, it's more convenient to supply a `config.php` file yourself. To skip the
+auto-configuration (and prevent mangling of the configuration), set the `SKIP_CONFIGURE` environment
+variable to any value.
+
 # Upgrade from version < 3.1.4
 Run the following command before performing the upgrade:
 `echo '-' > YOUR_STORAGE_VOLUME/storage/.installed`

--- a/src/configure.sh
+++ b/src/configure.sh
@@ -1,49 +1,51 @@
 #!/bin/sh
 
-export PHP_POST_MAX_SIZE=${PHP_UPLOAD_MAX_FILESIZE:-50m}
+if [ "${SKIP_CONFIGURE:-false}" == "false" ]; then
+	export PHP_POST_MAX_SIZE=${PHP_UPLOAD_MAX_FILESIZE:-50m}
 
-sed -i "s@50m@${PHP_UPLOAD_MAX_FILESIZE:-50m}@g" /opt/docker/etc/nginx/vhost.common.d/10-general.conf
+	sed -i "s@50m@${PHP_UPLOAD_MAX_FILESIZE:-50m}@g" /opt/docker/etc/nginx/vhost.common.d/10-general.conf
 
-if [ ! -f /app/config/config.php ]; then
-	mv /app/config.example.php /app/config/config.php
-	ln -s /app/config/config.php /app/config.php
-else
-	if [ -f /app/config.example.php ]; then
-		mv /app/config.example.php /app/config/config-newversion.php
-	fi
-	if [ ! -f /app/config.php ]; then
+	if [ ! -f /app/config/config.php ]; then
+		mv /app/config.example.php /app/config/config.php
 		ln -s /app/config/config.php /app/config.php
+	else
+		if [ -f /app/config.example.php ]; then
+			mv /app/config.example.php /app/config/config-newversion.php
+		fi
+		if [ ! -f /app/config.php ]; then
+			ln -s /app/config/config.php /app/config.php
+		fi
 	fi
-fi
 
-sed -i "s@https:\/\/localhost@$URL@g" /app/config.php
-sed -i "s/return\ \[/&\n\ \ \ \ \'app_name\' => \'$APP_NAME\',/" /app/config.php
+	sed -i "s@https:\/\/localhost@$URL@g" /app/config.php
+	sed -i "s/return\ \[/&\n\ \ \ \ \'app_name\' => \'$APP_NAME\',/" /app/config.php
 
-if [ "${DB_TYPE:-sqlite}" == "mysql" ]; then
-	sed -i "s/sqlite/mysql/g" /app/config.php
-	sed -i "s/realpath(__DIR__).'\/resources\/database\/xbackbone.db'/'host=$MYSQL_HOST;dbname=$MYSQL_DATABASE;charset=utf8mb4'/g" /app/config.php
-	sed -i "s/'username'   => null/'username'   => '$MYSQL_USER'/g" /app/config.php
-	sed -i "s/'password'   => null/'password'   => '$MYSQL_PASSWORD'/g" /app/config.php
-fi
+	if [ "${DB_TYPE:-sqlite}" == "mysql" ]; then
+		sed -i "s/sqlite/mysql/g" /app/config.php
+		sed -i "s/realpath(__DIR__).'\/resources\/database\/xbackbone.db'/'host=$MYSQL_HOST;dbname=$MYSQL_DATABASE;charset=utf8mb4'/g" /app/config.php
+		sed -i "s/'username'   => null/'username'   => '$MYSQL_USER'/g" /app/config.php
+		sed -i "s/'password'   => null/'password'   => '$MYSQL_PASSWORD'/g" /app/config.php
+	fi
 
-sed -i "/'ldap' *=>/d" /app/config.php
-sed -i "/'enabled' *=>/d" /app/config.php
-sed -i "/'host' *=>/d" /app/config.php
-sed -i "/'port' *=>/d" /app/config.php
-sed -i "/'base_domain' *=>/d" /app/config.php
-sed -i "/'user_domain' *=>/d" /app/config.php
-sed -i "/'rdn_attribute' *=>/d" /app/config.php
-sed -i "/], *\/\/ldap end/d" /app/config.php
+	sed -i "/'ldap' *=>/d" /app/config.php
+	sed -i "/'enabled' *=>/d" /app/config.php
+	sed -i "/'host' *=>/d" /app/config.php
+	sed -i "/'port' *=>/d" /app/config.php
+	sed -i "/'base_domain' *=>/d" /app/config.php
+	sed -i "/'user_domain' *=>/d" /app/config.php
+	sed -i "/'rdn_attribute' *=>/d" /app/config.php
+	sed -i "/], *\/\/ldap end/d" /app/config.php
 
-if [ "${LDAP_ENABLED:-false}" == "true" ]; then
-	sed -i "/^];/i\    'ldap' => [" config.php
-	sed -i "/^];/i\        'enabled'       => ${LDAP_ENABLED:-false}," /app/config.php
-	sed -i "/^];/i\        'host'          => '${LDAP_HOST:-ldap}'," /app/config.php
-	sed -i "/^];/i\        'port'          => ${LDAP_PORT:-389}," /app/config.php
-	sed -i "/^];/i\        'base_domain'   => '${LDAP_BASE_DOMAIN:-dc=example,dc=com}'," /app/config.php
-	sed -i "/^];/i\        'user_domain'   => '${LDAP_USER_DOMAIN:-ou=Users}'," /app/config.php
-	sed -i "/^];/i\        'rdn_attribute' => '${LDAP_RDN_ATTRIBUTE:-uid=}'," /app/config.php
-	sed -i "/^];/i\    ], //ldap end" config.php
+	if [ "${LDAP_ENABLED:-false}" == "true" ]; then
+		sed -i "/^];/i\    'ldap' => [" config.php
+		sed -i "/^];/i\        'enabled'       => ${LDAP_ENABLED:-false}," /app/config.php
+		sed -i "/^];/i\        'host'          => '${LDAP_HOST:-ldap}'," /app/config.php
+		sed -i "/^];/i\        'port'          => ${LDAP_PORT:-389}," /app/config.php
+		sed -i "/^];/i\        'base_domain'   => '${LDAP_BASE_DOMAIN:-dc=example,dc=com}'," /app/config.php
+		sed -i "/^];/i\        'user_domain'   => '${LDAP_USER_DOMAIN:-ou=Users}'," /app/config.php
+		sed -i "/^];/i\        'rdn_attribute' => '${LDAP_RDN_ATTRIBUTE:-uid=}'," /app/config.php
+		sed -i "/^];/i\    ], //ldap end" config.php
+	fi
 fi
 
 if [ ! -f /app/storage/.installed ]; then


### PR DESCRIPTION
The configure.sh script doesn't support all options and there's no need for it to. People can supply their own config.php. This makes the auto-configuration optional.